### PR TITLE
Fixes for Symfony YAML parser deprecation of filename support

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -101,7 +101,7 @@ class ClientBuilder
         if (!file_exists($file)) {
             throw new \InvalidArgumentException(sprintf('Configuration file "%s" not found', $file));
         }
-        $this->loadedConfig = Yaml::parse($file);
+        $this->loadedConfig = Yaml::parse(file_get_contents($file));
 
         return $this;
     }

--- a/src/Extension/NeoClientAuthExtension.php
+++ b/src/Extension/NeoClientAuthExtension.php
@@ -18,6 +18,6 @@ class NeoClientAuthExtension implements NeoClientExtensionInterface
 {
     public static function getAvailableCommands()
     {
-        return Yaml::parse(__DIR__.'/../Resources/extensions/auth_commands.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/../Resources/extensions/auth_commands.yml'));
     }
 }


### PR DESCRIPTION
The Symfony YAML parser has deprecated usage of filenames in the Yaml::parse method. This changes any calls to Yaml::parse that were previously using filenames to use file contents instead.

(This was causing Exceptions in a Laravel 5 project due to Symfony\Component\Yaml\Yaml.php:58 E_USER_DEPRECATED triggered error)