### PR TITLE
Prepared transaction 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.1
+
+### Bug fixes
+
+* getProperty() on relationship was returning always true
+* sendMultiple was not converting empty arrays to maps in the Request json body
+
+### Features
+
+* added Prepared Transaction instance for handling multiple statements in one commit
+
 ## 2.0
 
 * The bootstrap process has been changed

--- a/README.md
+++ b/README.md
@@ -355,6 +355,38 @@ $r = $client->sendCypherQuery($q)->getResult();
 print_r($r->get('flwers')); // Returns an array of node objects
 ```
 
+## Sending multiple statements in one transaction
+
+There are 3 ways for sending multiple statements in one and only transaction.
+
+1. Using an open transaction throughout the process (see the next section "Transaction Management")
+2. Creating an array of statements and sending it all together with the `sendMultiple` method
+3. Using a `PreparedTransaction` instance
+
+### Using sendMultiple
+
+If you want to build yourself an array of statements and send it once with sendMultiple :
+
+```php
+$statements = array();
+$statements[] = array('statement' => 'MATCH (n:User {id:{id}})', 'parameters' => ['id' => 123]);
+$statements[] = array('statement' => 'MATCH (n:User) RETURN count(n));
+$client->sendMultiple($statements);
+```
+
+### PreparedTransaction
+
+Handy if you want to keep a `PreparedTransaction` instance throughout your code :
+
+```php
+$tx = $client->prepareTransaction()
+    ->pushQuery($q, $p)
+    ->pushQuery($q2)
+    ->pushQuery($q3)
+    ->commit();
+```
+
+
 ## Transaction Management
 
 The library comes with a Transaction Manager removing you the burden of parsing commit urls and transaction ids.

--- a/src/Command/Core/CoreSendMultipleCypherCommand.php
+++ b/src/Command/Core/CoreSendMultipleCypherCommand.php
@@ -42,8 +42,17 @@ class CoreSendMultipleCypherCommand extends AbstractCommand
 
     public function prepareBody()
     {
+        $sts = [];
+        foreach ($this->statements as $statement) {
+            $statement['resultDataContents'] = $this->resultDataContents;
+            if (empty($statement['parameters'])) {
+                unset($statement['parameters']);
+            }
+            $sts[] = $statement;
+        }
+
         $body = array(
-            'statements' => $this->statements
+            'statements' => $sts
         );
 
         return json_encode($body);

--- a/src/Extension/NeoClientCoreExtension.php
+++ b/src/Extension/NeoClientCoreExtension.php
@@ -91,10 +91,10 @@ class NeoClientCoreExtension extends AbstractExtension
      * @param  null                                   $conn
      * @return \Neoxygen\NeoClient\Formatter\Response
      */
-    public function sendMultiple(array $statements, $conn = null)
+    public function sendMultiple(array $statements, $conn = null, $queryMode = null)
     {
         $command = $this->invoke('neo.send_cypher_multiple', $conn);
-        $command->setArguments($statements);
+        $command->setArguments($statements, $this->resultDataContent, $queryMode);
         $httpResponse = $command->execute();
 
         return $this->handleHttpResponse($httpResponse);

--- a/src/Extension/NeoClientCoreExtension.php
+++ b/src/Extension/NeoClientCoreExtension.php
@@ -12,6 +12,7 @@
 
 namespace Neoxygen\NeoClient\Extension;
 
+use Neoxygen\NeoClient\Transaction\PreparedTransaction;
 use Symfony\Component\Yaml\Yaml;
 use Neoxygen\NeoClient\Transaction\Transaction,
     Neoxygen\NeoClient\Request\Response;
@@ -97,6 +98,15 @@ class NeoClientCoreExtension extends AbstractExtension
         $httpResponse = $command->execute();
 
         return $this->handleHttpResponse($httpResponse);
+    }
+
+    /**
+     * @param null|string $conn Connection alias
+     * @return PreparedTransaction
+     */
+    public function prepareTransaction($conn = null)
+    {
+        return new PreparedTransaction($conn);
     }
 
     /**

--- a/src/Transaction/PreparedTransaction.php
+++ b/src/Transaction/PreparedTransaction.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This file is part of the Neoclient package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Neoxygen\NeoClient\Transaction;
+
+use Neoxygen\NeoClient\Exception\CommandException;
+use Neoxygen\NeoClient\Client;
+
+class PreparedTransaction
+{
+    /**
+     * @var array
+     */
+    protected $statements = [];
+
+    /**
+     * @var null|string
+     */
+    protected $connection;
+
+    /**
+     * @var bool
+     */
+    protected $committed;
+
+    /**
+     * @param null|string $connection Connection alias
+     */
+    public function __construct($connection = null)
+    {
+        if (null !== $connection) {
+            $this->connection = (string) $connection;
+        }
+        $this->committed = false;
+
+        return $this;
+    }
+
+    /**
+     * @param $q
+     * @param null|array $p
+     * @return $this
+     */
+    public function pushQuery($q, $p = array())
+    {
+        if (!is_array($p)) {
+            throw new CommandException('Cypher query parameters should be of type array or null');
+        }
+        $this->statements[] = array(
+            'statements' => $q,
+            'parameters' => $p
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasStatements()
+    {
+        if (!empty($this->statements)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function getStatements()
+    {
+        return $this->statements;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Commit the prepared transaction
+     *
+     * @return mixed
+     * @throws \Neoxygen\NeoClient\Exception\CommandException if the transaction was already committed
+     */
+    public function commit()
+    {
+        if ($this->committed) {
+            throw new CommandException('The prepared transaction has already been commited');
+        }
+
+        $response = Client::commitPreparedTransaction($this);
+        $this->committed = true;
+
+        return $response;
+    }
+}

--- a/src/Transaction/PreparedTransaction.php
+++ b/src/Transaction/PreparedTransaction.php
@@ -54,7 +54,7 @@ class PreparedTransaction
             throw new CommandException('Cypher query parameters should be of type array or null');
         }
         $this->statements[] = array(
-            'statements' => $q,
+            'statement' => $q,
             'parameters' => $p
         );
 


### PR DESCRIPTION
This add the possibility to prepare a transaction with multiple statements. This fixes issue #26 .

```
$tx = $client->prepareTransaction()
   ->pushQuery('MATCH (n) RETURN count(n)
   ->pushQuery('CREATE (n)')
   ->commit();

print_r($tx->getResult());
```
