### PR TITLE
Update the use of Yaml::parse passing file content

### DIFF
--- a/src/Extension/NeoClientCoreExtension.php
+++ b/src/Extension/NeoClientCoreExtension.php
@@ -21,7 +21,7 @@ class NeoClientCoreExtension extends AbstractExtension
 {
     public static function getAvailableCommands()
     {
-        return Yaml::parse(__DIR__.'/../Resources/extensions/core_commands.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/../Resources/extensions/core_commands.yml'));
     }
 
     /**


### PR DESCRIPTION
Getting this error:

```
The ability to pass file names to the Symfony\Component\Yaml\Yaml::parse method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead.

/Users/mulkave/Developer/sandbox/neoclient-tryout/vendor/neoxygen/neoclient/src/Extension/NeoClientCoreExtension.php:24
/Users/mulkave/Developer/sandbox/neoclient-tryout/vendor/neoxygen/neoclient/src/DependencyInjection/Compiler/NeoClientExtensionsCompilerPass.php:33
/Users/mulkave/Developer/sandbox/neoclient-tryout/vendor/symfony/dependency-injection/Compiler/Compiler.php:117
/Users/mulkave/Developer/sandbox/neoclient-tryout/vendor/symfony/dependency-injection/ContainerBuilder.php:614
/Users/mulkave/Developer/sandbox/neoclient-tryout/vendor/neoxygen/neoclient/src/ClientBuilder.php:447
```