### PR TITLE
Allow scalar node value for port

### DIFF
--- a/src/DependencyInjection/Definition.php
+++ b/src/DependencyInjection/Definition.php
@@ -37,7 +37,7 @@ class Definition implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->scalarNode('host')->defaultValue('localhost')->end()
-                    ->integerNode('port')->defaultValue('7474')->end()
+                    ->scalarNode('port')->defaultValue('7474')->end()
                     ->booleanNode('auth')->defaultValue(false)->end()
                     ->scalarNode('user')->end()
                     ->scalarNode('password')->end()

--- a/src/DependencyInjection/NeoClientExtension.php
+++ b/src/DependencyInjection/NeoClientExtension.php
@@ -102,7 +102,7 @@ class NeoClientExtension implements  ExtensionInterface
                 ->addArgument($connectionAlias)
                 ->addArgument($settings['scheme'])
                 ->addArgument($settings['host'])
-                ->addArgument($settings['port'])
+                ->addArgument((int)$settings['port'])
                 ->addTag('neoclient.registered_connection')
                 ->setLazy(true);
             if (isset($settings['auth']) && true === $settings['auth']) {


### PR DESCRIPTION
Using a scalar node as valid value for the port and later forcing the int value, making it possible to use strings in configuration. This behaviour is equal to the DoctrineBundle. That bundle uses the same strategy to allow scalar values. This benefits certain deployment styles.

For example, I'm currently using ansible and ansible-vault to set the parameters of my Symfony application. The templating ansible uses (jinja) is a little more strict and doesn't allow integer nodes.