### PR TITLE
Support for Symfony 3.0

### DIFF
--- a/src/DependencyInjection/Definition.php
+++ b/src/DependencyInjection/Definition.php
@@ -76,7 +76,7 @@ class Definition implements ConfigurationInterface
         ->end()
         ->arrayNode('ha_mode')
             ->children()
-                ->booleanNode('enabled')->CanNotBeEmpty()->end()
+                ->booleanNode('enabled')->defaultValue(false)->end()
                 ->scalarNode('query_mode_header_key')->defaultValue('Neo4j-Query-Mode')->end()
                 ->scalarNode('write_mode_header_value')->defaultValue('NEO4J_QUERY_WRITE')->end()
                 ->scalarNode('read_mode_header_value')->defaultValue('NEO4J_QUERY_READ')->end()


### PR DESCRIPTION
In Symfony 3.0, the method `CanNotBeEmpty` on `BooleanNodeDefinition` has been deprecated. I've replaced this call by `setDefaultValue(false)` : I hope it won't cause too much trouble and won't break compatibility.
